### PR TITLE
Feat/find dart files from directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.3.0
+ * add ability to find dart files in a directory
+
 ## 0.2.1
  * bump deps
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ results need to be incorporated.
 To extract messages, run the `extract_to_arb.dart` program.
 
       pub run intl_generator:extract_to_arb --output-dir=target/directory
-          my_program.dart more_of_my_program.dart
+          my_program.dart more_of_my_program.dart my/target/programs/directory
 
 This will produce a file `intl_messages.arb` with the messages from all of these
 programs. This is an [ARB][ARB] format file which can be used for input to
@@ -32,7 +32,7 @@ locale.
 
 ```
 pub run intl_generator:generate_from_arb --generated-file-prefix=<prefix>
-    <my_dart_files> <translated_ARB_files>
+    <my_dart_files> <my_dart_files_directory> <translated_ARB_files>
 ```
 
 This will generate Dart libraries, one per locale, which contain the

--- a/bin/extract_to_arb.dart
+++ b/bin/extract_to_arb.dart
@@ -17,7 +17,7 @@ import 'package:intl_generator/src/arb_generation.dart';
 import 'package:intl_generator/src/directory_utils.dart';
 import 'package:path/path.dart' as path;
 
-main(List<String> args) {
+Future<void> main(List<String> args) async {
   var targetDir;
   var outputFilename;
   String? sourcesListFile;
@@ -92,7 +92,8 @@ main(List<String> args) {
     allMessages["@@last_modified"] = new DateTime.now().toIso8601String();
   }
 
-  var dartFiles = args.where((x) => x.endsWith(".dart")).toList();
+  final List<String> dartFiles = await findDartFilesInDirectories(args);
+  dartFiles.addAll(args.where((String file) => file.endsWith(".dart")));
   dartFiles.addAll(linesFromFile(sourcesListFile));
   for (var arg in dartFiles) {
     var messages = extraction.parseFile(new File(arg), transformer);

--- a/bin/generate_from_arb.dart
+++ b/bin/generate_from_arb.dart
@@ -35,7 +35,7 @@ late Map<String, List<MainMessage>> messages;
 
 const jsonDecoder = const JsonCodec();
 
-main(List<String> args) {
+Future<void> main(List<String> args) async {
   var targetDir;
   var parser = new ArgParser();
   var extraction = new MessageExtraction();
@@ -86,7 +86,8 @@ main(List<String> args) {
           "don't need to be specified for messages.");
 
   parser.parse(args);
-  var dartFiles = args.where((x) => x.endsWith("dart")).toList();
+  final List<String> dartFiles = await findDartFilesInDirectories(args);
+  dartFiles.addAll(args.where((String file) => file.endsWith(".dart")));
   var jsonFiles = args.where((x) => x.endsWith(".arb")).toList();
   dartFiles.addAll(linesFromFile(sourcesListFile));
   jsonFiles.addAll(linesFromFile(translationsListFile));

--- a/lib/src/directory_utils.dart
+++ b/lib/src/directory_utils.dart
@@ -30,3 +30,32 @@ String _relativeToBase(String base, String filename) {
     return filename;
   }
 }
+
+List<Directory> _findDirectories(List<String> paths) {
+  final List<Directory> directories = <Directory>[];
+  for (final String path in paths) {
+    if (FileSystemEntity.typeSync(path) == FileSystemEntityType.directory) {
+      directories.add(Directory(path));
+    }
+  }
+  return directories;
+}
+
+Future<List<String>> findDartFilesInDirectories(
+  List<String> paths,
+) async {
+  final List<Directory> directories = _findDirectories(paths);
+  final List<String> dartFiles = <String>[];
+
+  for (final Directory directory in directories) {
+    final List<FileSystemEntity> entities =
+        await directory.list(recursive: true).toList();
+    final Iterable<FileSystemEntity> files = entities.where(_isDartFile);
+    dartFiles.addAll(files.map((FileSystemEntity file) => file.path));
+  }
+  return dartFiles;
+}
+
+bool _isDartFile(FileSystemEntity entity) {
+  return entity is File && entity.path.endsWith(".dart");
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: intl_generator
-version: 0.2.1
+version: 0.3.0
 description: >-
   Contains code to deal with internationalized/localized messages,
   date and number formatting and parsing, bi-directional text, and


### PR DESCRIPTION
## Motivation
I recently refactored a code base that has localization and it's now becoming larger. Now, the main localization.dart file has become a monolith that contains all localized words that have different context. So I decided to split them by feature in `mixins`. However, both `extract_to_arb` and `generate_from_arb` **does not** support generating arb file from directory containing all the .dart files. 

## Goal
This PR gives this library the ability to find all dart files from directories given by user.