### PR TITLE
chore: Remove intl dependency upper constraint

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   analyzer: ">=5.1.0 <6.0.0"
   args: ">=2.1.0 <3.0.0"
   dart_style: ^2.2.4
-  intl: ">=0.17.0 <0.20.0"
+  intl: ">=0.17.0"
   path: ">=1.8.0 <2.0.0"
   petitparser: ">=5.0.0 <6.0.0"
 dev_dependencies:


### PR DESCRIPTION
To support Flutter 3.32.8